### PR TITLE
🔧 Fix BLOG_DOMAIN variable source in hatena workflows

### DIFF
--- a/.github/workflows/hatena-create-draft.yaml
+++ b/.github/workflows/hatena-create-draft.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: set blog domain
         id: set-domain
         run: |
-          domain=${{ inputs.BLOG_DOMAIN }}
+          domain=${{ vars.BLOG_DOMAIN }}
           echo "BLOG_DOMAIN=$(echo $domain | tr -d '\n\r ')" >> "$GITHUB_OUTPUT"
       - name: post draft to hatenablog
         id: post-draft

--- a/.github/workflows/hatena-pull-draft.yaml
+++ b/.github/workflows/hatena-pull-draft.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: set blog domain
         id: set-domain
         run: |
-          domain=${{ inputs.BLOG_DOMAIN }}
+          domain=${{ vars.BLOG_DOMAIN }}
           echo "BLOG_DOMAIN=$(echo $domain | tr -d '\n\r ')" >> "$GITHUB_OUTPUT"
       - name: pull
         run: |

--- a/.github/workflows/hatena-pull.yaml
+++ b/.github/workflows/hatena-pull.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: set blog domain
         id: set-domain
         run: |
-          domain=${{ inputs.BLOG_DOMAIN }}
+          domain=${{ vars.BLOG_DOMAIN }}
           echo "BLOG_DOMAIN=$(echo $domain | tr -d '\n\r ')" >> "$GITHUB_OUTPUT"
       - name: pull
         run: |


### PR DESCRIPTION
## Overview 🎯

GitHub Actions のはてなワークフローで BLOG_DOMAIN 変数の参照元を修正し、自動トリガー時の動作を正常化しました。

## Changes ✏️

- `hatena-create-draft.yaml` で `inputs.BLOG_DOMAIN` を `vars.BLOG_DOMAIN` に修正
- `hatena-pull-draft.yaml` で `inputs.BLOG_DOMAIN` を `vars.BLOG_DOMAIN` に修正  
- `hatena-pull.yaml` で `inputs.BLOG_DOMAIN` を `vars.BLOG_DOMAIN` に修正

## How to Test 🧪

1. 各ワークフローを手動実行し、BLOG_DOMAIN が正しく取得されることを確認
2. リポジトリ変数が適切に参照されることを検証
3. workflow_dispatch および workflow_call の両方で動作することを確認

## Related 🔗

前回のリファクタリング (#5) で見逃していた変数参照の修正

## Notes 🗒️

- workflow_dispatch 時は inputs が存在しないため vars を使用する必要がある
- この修正により自動トリガー時のエラーを解消