### PR TITLE
✨ Add local hatena-upload-images workflow

### DIFF
--- a/.github/workflows/hatena-push-draft.yaml
+++ b/.github/workflows/hatena-push-draft.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   upload-images:
-    uses: hatena/hatenablog-workflows/.github/workflows/upload-images.yaml@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
+    uses: ./.github/workflows/hatena-upload-images.yaml
     secrets:
       OWNER_API_KEY: ${{ secrets.OWNER_API_KEY }}
   push-draft:

--- a/.github/workflows/hatena-push-published-entries.yaml
+++ b/.github/workflows/hatena-push-published-entries.yaml
@@ -12,6 +12,6 @@ on:
 jobs:
   upload-images:
     if: github.event.pull_request.merged == false
-    uses: hatena/hatenablog-workflows/.github/workflows/upload-images.yaml@ce4c0e01255ad9348842e5ce09809c3ec499e43d # v2.0.5
+    uses: ./.github/workflows/hatena-upload-images.yaml
     secrets:
       OWNER_API_KEY: ${{ secrets.OWNER_API_KEY }}

--- a/.github/workflows/hatena-upload-images.yaml
+++ b/.github/workflows/hatena-upload-images.yaml
@@ -1,0 +1,65 @@
+name: "Hatena - Upload Images"
+
+on:
+  workflow_call:
+    secrets:
+      OWNER_API_KEY:
+        required: true
+    outputs:
+      revision:
+        value: ${{ jobs.upload-image.outputs.revision }}
+
+jobs:
+  upload-image:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./hatena
+    outputs:
+      revision: ${{ steps.commit-and-push.outputs.revision }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: list changed entries
+        id: changed-entries
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
+        with:
+          files: |
+            **.md
+      - name: set owner
+        id: set-owner
+        run: |
+          owner=$(yq "..|.owner|select(.)" blogsync.yaml)
+          if [[ -z "$owner" ]]; then
+            owner=$(yq "..|.username|select(.)" blogsync.yaml)
+          fi
+          echo "OWNER_ID=$owner" >> $GITHUB_OUTPUT
+      - name: Download the script
+        run: |
+          curl -fsSL -o /tmp/fotolife-client.py https://raw.githubusercontent.com/hatena/hatenablog-workflows/v1/fotolife-client.py
+          chmod +x /tmp/fotolife-client.py
+      - name: List all changed files markdown files
+        if: steps.changed-entries.outputs.any_changed == 'true'
+        run: |
+          for f in ${{ steps.changed-entries.outputs.all_changed_files }}; do
+            python3 /tmp/fotolife-client.py "$f"
+          done
+        env:
+          HATENA_ID: ${{ steps.set-owner.outputs.OWNER_ID }}
+          OWNER_API_KEY: ${{ secrets.OWNER_API_KEY }}
+      - name: commit & push
+        id: commit-and-push
+        run: |
+          git config user.name "actions-user"
+          git config user.email "action@github.com"
+          if [[ $(git diff) -eq 0 ]]; then
+            exit 0
+          fi
+
+          git add .
+          git commit -m "upload images to fotolife"
+          git push
+
+          revision=$(git rev-parse HEAD)
+          echo "REVISION=$revision" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Overview 🎯

外部のupload-images ワークフローをローカルに複製し、画像アップロード処理の制御性と保守性を向上させました。

## Changes ✏️

- `hatena-upload-images.yaml` ワークフローを新規作成
- fotolife-client.py スクリプトによる画像アップロード機能を統合
- `hatena-push-draft.yaml` で外部upload-images ワークフローをローカルに変更
- `hatena-push-published-entries.yaml` で外部upload-images ワークフローをローカルに変更
- workflow_call インターフェースとrevision出力をサポート
- 変更されたMarkdownファイルの自動検出と処理

## How to Test 🧪

1. 画像を含むMarkdownファイルでプルリクエストを作成
2. hatena-push-draft ワークフローが正常に実行されることを確認
3. 画像が正しくfotolifeにアップロードされることを検証
4. revision出力が適切に次のジョブに渡されることを確認

## Related 🔗

外部依存の `hatena/hatenablog-workflows` upload-images から脱却し、画像処理の制御性を向上

## Notes 🗒️

- 外部ワークフローへの依存を排除
- 画像アップロード処理のカスタマイズが容易
- デバッグとトラブルシューティングが改善
- fotolife-client.py スクリプトは外部から取得（将来的にローカル化検討）