### PR TITLE
🔧 Update Qiita workflow to use direct CLI commands

### DIFF
--- a/.github/workflows/qiita-publish.yaml
+++ b/.github/workflows/qiita-publish.yaml
@@ -27,7 +27,14 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-      - uses: increments/qiita-cli/actions/publish@1fe96670b4119691673e476017fcc61d0d6a6246 # v1.6.2
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          qiita-token: ${{ secrets.QIITA_TOKEN }}
-          root: "."
+          node-version: "22.x"
+      - name: Install dependencies
+        run: npm install
+        shell: bash
+      - name: Publish articles
+        run: npx qiita publish --all --root .
+        env:
+          QIITA_TOKEN: ${{ secrets.QIITA_TOKEN }}
+        shell: bash


### PR DESCRIPTION
## Overview 🎯

Replace the `increments/qiita-cli/actions/publish` GitHub Action with direct Node.js setup and `npx qiita` command execution for better control and debugging capabilities.

## Changes ✏️

- Replaced `increments/qiita-cli/actions/publish@1fe96670b4119691673e476017fcc61d0d6a6246` action with manual setup
- Added `actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020` for Node.js 22.x environment
- Added explicit `npm install` step to install dependencies
- Added direct `npx qiita publish --all --root .` execution with environment variable configuration

## How to Test 🧪

1. Create or modify an article in the `public/` directory
2. Push changes to trigger the workflow
3. Verify the workflow runs successfully and articles are published to Qiita
4. Check workflow logs for proper execution of each step

## Related 🔗

Part of Qiita workflow optimization and maintenance efforts.

## Notes 🗒️

- This change provides better visibility into the publishing process through explicit steps
- Maintains the same security practices with pinned action versions using commit SHA
- Environment variable `QIITA_TOKEN` usage remains unchanged