### PR TITLE
🤖 Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "malleroid"
+    assignees:
+      - "malleroid"
+    commit-message:
+      prefix: "⬆️"
+      include: "scope"


### PR DESCRIPTION
## Overview 🎯

Add Dependabot configuration to automatically manage GitHub Actions dependencies with weekly updates scheduled for Japanese business hours.

## Changes ✏️

- Created `.github/dependabot.yml` with GitHub Actions package ecosystem configuration
- Set weekly update schedule for Mondays at 09:00 JST
- Configured PR management with 10 concurrent PR limit
- Added automatic reviewer and assignee settings
- Set commit message prefix to ⬆️ for dependency updates

## How to Test 🧪

1. Verify the Dependabot configuration file syntax is valid
2. Check that GitHub recognizes the configuration (visible in repository Insights > Dependency graph > Dependabot)
3. Wait for the first scheduled run on Monday 09:00 JST or trigger manually if GitHub Actions dependencies need updates

## Related 🔗

Setup for automated dependency management as part of repository maintenance improvements.

## Notes 🗒️

- Dependabot will automatically create PRs for GitHub Actions updates
- PRs will be limited to 10 concurrent ones to avoid overwhelming the repository
- All dependency update PRs will be automatically assigned to @malleroid for review